### PR TITLE
Clean up unused cart effect

### DIFF
--- a/src/app/state/cart.effects.ts
+++ b/src/app/state/cart.effects.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { debounceTime, tap, withLatestFrom } from 'rxjs/operators';
-import { addToCart, removeFromCart, updateQuantity, loadCartState } from './cart.actions';  // Importar las acciones
+import { addToCart, removeFromCart, updateQuantity } from './cart.actions';  // Importar las acciones
 import { CartState } from './cart.reducer';  // Importar el estado del carrito
 
 @Injectable()
@@ -23,19 +23,4 @@ export class CartEffects {
     { dispatch: false }
   );
   
-
-
-  loadCartFromLocalStorage$ = createEffect(() =>
-    this.actions$.pipe(
-      ofType('[App] Load Cart From LocalStorage'), 
-      tap(() => {
-        const savedCart = localStorage.getItem('cart-state');
-        if (savedCart) {
-          const cartState = JSON.parse(savedCart);
-          this.store.dispatch(loadCartState({ items: cartState.items }));  
-        }
-      })
-    ),
-    { dispatch: false }  
-  );
 }


### PR DESCRIPTION
## Summary
- remove unused `loadCartFromLocalStorage$` effect

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684713b995f4832a8b7c074efd270619