### PR TITLE
Add size/color arrays and image size validation

### DIFF
--- a/src/app/modules/admin/components/inventory-form/inventory-form.component.html
+++ b/src/app/modules/admin/components/inventory-form/inventory-form.component.html
@@ -1,26 +1,56 @@
+<h2 class="text-2xl font-semibold mb-4">{{ isEdit ? 'Editar' : 'Crear' }} Producto</h2>
+<form [formGroup]="form" (ngSubmit)="save()" class="max-w-2xl mx-auto bg-white p-6 rounded shadow-md">
+  <div class="mb-4">
+    <label class="block text-gray-700 text-sm font-bold mb-2">Nombre<span class="text-red-500">*</span></label>
+    <input formControlName="name" type="text" placeholder="Nombre" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" />
+    <p class="text-red-500 text-xs italic mt-1" *ngIf="form.get('name')?.invalid && (submitted || form.get('name')?.touched)">El nombre es requerido.</p>
+  </div>
+  <div class="mb-4">
+    <label class="block text-gray-700 text-sm font-bold mb-2">Descripción<span class="text-red-500">*</span></label>
+    <textarea formControlName="description" placeholder="Descripción" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"></textarea>
+    <p class="text-red-500 text-xs italic mt-1" *ngIf="form.get('description')?.invalid && (submitted || form.get('description')?.touched)">La descripción es requerida.</p>
+  </div>
+  <div class="mb-4">
+    <label class="block text-gray-700 text-sm font-bold mb-2">Cantidad<span class="text-red-500">*</span></label>
+    <input formControlName="quantity" type="number" min="0" placeholder="Cantidad" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" />
+    <p class="text-red-500 text-xs italic mt-1" *ngIf="form.get('quantity')?.invalid && (submitted || form.get('quantity')?.touched)">La cantidad debe ser mayor o igual a 0.</p>
+  </div>
+  <div class="mb-4">
+    <label class="block text-gray-700 text-sm font-bold mb-2">Precio<span class="text-red-500">*</span></label>
+    <input formControlName="price" type="number" min="0" placeholder="Precio" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" />
+    <p class="text-red-500 text-xs italic mt-1" *ngIf="form.get('price')?.invalid && (submitted || form.get('price')?.touched)">El precio debe ser mayor o igual a 0.</p>
+  </div>
+  <div class="mb-4" formArrayName="size">
+    <label class="block text-gray-700 text-sm font-bold mb-2">Tallas</label>
+    <div *ngFor="let ctrl of sizeControls.controls; let i = index" class="flex mb-2">
+      <input [formControlName]="i" type="text" placeholder="Ej: S" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" />
+      <button type="button" (click)="removeSize(i)" class="ml-2 text-red-500" *ngIf="sizeControls.length > 1">Eliminar</button>
+    </div>
+    <button type="button" (click)="addSize()" class="text-blue-500">Agregar talla</button>
+  </div>
 
-<h2>{{ isEdit ? 'Editar' : 'Crear' }} Producto</h2>
-<form [formGroup]="form" (ngSubmit)="save()">
-  <div>
-    <label>Nombre</label>
-    <input formControlName="name" placeholder="Nombre" />
-    <div *ngIf="form.get('name')?.invalid && form.get('name')?.touched" style="color:red;">
-      El nombre es requerido.
+  <div class="mb-4" formArrayName="color">
+    <label class="block text-gray-700 text-sm font-bold mb-2">Colores</label>
+    <div *ngFor="let ctrl of colorControls.controls; let i = index" class="flex mb-2">
+      <input [formControlName]="i" type="text" placeholder="Ej: Rojo" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" />
+      <button type="button" (click)="removeColor(i)" class="ml-2 text-red-500" *ngIf="colorControls.length > 1">Eliminar</button>
     </div>
+    <button type="button" (click)="addColor()" class="text-blue-500">Agregar color</button>
   </div>
-  <div>
-    <label>Cantidad</label>
-    <input formControlName="quantity" type="number" placeholder="Cantidad" />
-    <div *ngIf="form.get('quantity')?.invalid && form.get('quantity')?.touched" style="color:red;">
-      La cantidad debe ser mayor o igual a 0.
-    </div>
+  <div class="mb-4">
+    <label class="block text-gray-700 text-sm font-bold mb-2">Imágenes<span class="text-red-500">*</span></label>
+    <input formControlName="images" type="file" multiple (change)="onFileChange($event)" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" />
+    <p class="text-red-500 text-xs italic mt-1" *ngIf="form.get('images')?.hasError('required') && (submitted || form.get('images')?.touched)">Debe seleccionar al menos una imagen.</p>
+    <p class="text-red-500 text-xs italic mt-1" *ngIf="form.get('images')?.hasError('maxFileSize') && (submitted || form.get('images')?.touched)">Cada imagen debe pesar menos de 2MB.</p>
   </div>
-  <div>
-    <label>Precio</label>
-    <input formControlName="price" type="number" placeholder="Precio" />
-    <div *ngIf="form.get('price')?.invalid && form.get('price')?.touched" style="color:red;">
-      El precio debe ser mayor o igual a 0.
-    </div>
+  <div class="mb-4 flex items-center">
+    <input id="isNew" formControlName="isNew" type="checkbox" class="mr-2" />
+    <label for="isNew" class="text-gray-700 text-sm font-bold">Es nuevo</label>
+    <p class="text-red-500 text-xs italic mt-1 ml-2" *ngIf="form.get('isNew')?.invalid && (submitted || form.get('isNew')?.touched)">Debe indicar si el producto es nuevo.</p>
   </div>
-  <button type="submit" [disabled]="form.invalid">Guardar</button>
+  <div class="flex items-center justify-between">
+    <button type="submit" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" [disabled]="form.invalid">
+      {{ isEdit ? 'Actualizar' : 'Guardar' }}
+    </button>
+  </div>
 </form>

--- a/src/app/modules/admin/components/inventory-form/inventory-form.component.ts
+++ b/src/app/modules/admin/components/inventory-form/inventory-form.component.ts
@@ -1,8 +1,23 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { FormBuilder, FormGroup, Validators, FormArray, AbstractControl, ValidatorFn } from '@angular/forms';
 import { InventoryServiceService, InventoryItem } from 'src/app/services/inventory-service.service';
 import {generateDate} from 'src/app/utils/utils';
+
+export function maxFileSizeValidator(maxMb: number): ValidatorFn {
+  const max = maxMb * 1024 * 1024;
+  return (control: AbstractControl) => {
+    const files: FileList = control.value;
+    if (files) {
+      for (let i = 0; i < files.length; i++) {
+        if (files.item(i) && files.item(i)!.size > max) {
+          return { maxFileSize: true };
+        }
+      }
+    }
+    return null;
+  };
+}
 
 @Component({
   selector: 'app-inventory-form',
@@ -15,6 +30,7 @@ export class InventoryFormComponent implements OnInit {
   form: FormGroup;
   isEdit = false;
   itemId: string | null = null;
+  submitted = false;
 
   constructor(
     private fb: FormBuilder,
@@ -26,10 +42,10 @@ export class InventoryFormComponent implements OnInit {
       name: ['', Validators.required],
       description: ['', Validators.required],
       price: [0, [Validators.required, Validators.min(0)]],
-      size: [[], []], // optional array
-      color: [[], []], // optional array
+      size: this.fb.array([this.fb.control('')]),
+      color: this.fb.array([this.fb.control('')]),
       quantity: [0, [Validators.required, Validators.min(0)]],
-      images: [[], Validators.required], // array, required
+      images: [null, [Validators.required, maxFileSizeValidator(2)]],
       isNew: [false, Validators.required]
     });
   }
@@ -39,14 +55,64 @@ export class InventoryFormComponent implements OnInit {
     if (this.itemId) {
       const found = this.inventoryService.getItemById(this.itemId);
       if (found) {
-        this.form.patchValue(found);
+        this.form.patchValue({
+          name: found.name,
+          description: (found as any).description,
+          price: found.price,
+          quantity: found.quantity,
+          isNew: (found as any).isNew
+        });
+        if ((found as any).size) {
+          const sizeArray = this.form.get('size') as FormArray;
+          sizeArray.clear();
+          (found as any).size.forEach((s: string) => sizeArray.push(this.fb.control(s)));
+        }
+        if ((found as any).color) {
+          const colorArray = this.form.get('color') as FormArray;
+          colorArray.clear();
+          (found as any).color.forEach((c: string) => colorArray.push(this.fb.control(c)));
+        }
         this.isEdit = true;
       }
     }
   }
 
+  get sizeControls(): FormArray {
+    return this.form.get('size') as FormArray;
+  }
+
+  get colorControls(): FormArray {
+    return this.form.get('color') as FormArray;
+  }
+
+  addSize(): void {
+    this.sizeControls.push(this.fb.control(''));
+  }
+
+  removeSize(index: number): void {
+    this.sizeControls.removeAt(index);
+  }
+
+  addColor(): void {
+    this.colorControls.push(this.fb.control(''));
+  }
+
+  removeColor(index: number): void {
+    this.colorControls.removeAt(index);
+  }
+
+  onFileChange(event: any): void {
+    const files: FileList = event.target.files;
+    this.form.get('images')?.setValue(files);
+    this.form.get('images')?.updateValueAndValidity();
+  }
+
 save() {
-    if (this.form.invalid) return;
+    this.submitted = true;
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
     const formValue = this.form.value;
     if (this.isEdit && this.itemId) {
       this.inventoryService.updateItem({ id: this.itemId, ...formValue });


### PR DESCRIPTION
## Summary
- allow multiple sizes and colors with FormArray controls
- validate each uploaded image is under 2MB and handle file selection
- show controls to add/remove sizes and colors

## Testing
- `npx ng test --watch=false` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68473ad90ec4832ab40a893d33130de9