### PR TITLE
Add image preview to inventory form

### DIFF
--- a/src/app/modules/admin/components/inventory-form/inventory-form.component.html
+++ b/src/app/modules/admin/components/inventory-form/inventory-form.component.html
@@ -46,6 +46,10 @@
   <p class="text-gray-500 text-xs mt-2" *ngIf="selectedFiles.length > 0">
     Imágenes seleccionadas: {{ selectedFiles.length }} de 5
   </p>
+  <div class="flex flex-wrap mt-2" *ngIf="previewUrls.length > 0">
+    <img *ngFor="let url of previewUrls" [src]="url" alt="preview"
+         class="w-24 h-24 object-cover mr-2 mb-2 rounded border" />
+  </div>
 </div>
 
 

--- a/src/app/modules/admin/components/inventory-form/inventory-form.component.ts
+++ b/src/app/modules/admin/components/inventory-form/inventory-form.component.ts
@@ -34,6 +34,7 @@ export class InventoryFormComponent implements OnInit {
   itemId: string | null = null;
   submitted = false;
   selectedFiles: File[] = [];
+  previewUrls: string[] = [];
 
   constructor(
     private fb: FormBuilder,
@@ -113,9 +114,14 @@ onFileChange(event: any): void {
       return;
     }
 
-    // Añadir las nuevas imágenes seleccionadas
+    // Añadir las nuevas imágenes seleccionadas y generar sus vistas previas
     Array.from(files).forEach(file => {
       this.selectedFiles.push(file);
+      const reader = new FileReader();
+      reader.onload = (e: any) => {
+        this.previewUrls.push(e.target.result as string);
+      };
+      reader.readAsDataURL(file);
     });
 
     // Actualizar el formulario sin intentar modificar el valor del input file


### PR DESCRIPTION
## Summary
- preview uploaded images in admin inventory form

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68475caf6770832a87d29a8919bd0d78