### PR TITLE
Add login module and link

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -5,6 +5,7 @@ const routes: Routes = [
   { path: 'products', loadChildren: () => import('./modules/product/product.module').then(m => m.ProductModule)},
   { path: 'cart', loadChildren: () => import('./modules/shopping-cart/shopping-cart.module').then(m => m.ShoppingCartModule)},
   { path: 'admin', loadChildren: () => import('./modules/admin/admin.module').then(m => m.AdminModule) },
+  { path: 'login', loadChildren: () => import('./modules/login/login.module').then(m => m.LoginModule)},
   { path: '', redirectTo: '/products', pathMatch: 'full' },
   
   { path: '**', redirectTo: '/products' } 

--- a/src/app/modules/login/components/login/login.component.html
+++ b/src/app/modules/login/components/login/login.component.html
@@ -1,0 +1,23 @@
+<div class="flex justify-center mt-10">
+  <form class="w-full max-w-sm" (ngSubmit)="login()">
+    <div class="mb-4">
+      <label class="block text-gray-700 text-sm font-bold mb-2" for="email">
+        Correo electrónico
+      </label>
+      <input id="email" type="email" [(ngModel)]="email" name="email" required
+             class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" />
+    </div>
+    <div class="mb-6">
+      <label class="block text-gray-700 text-sm font-bold mb-2" for="password">
+        Contraseña
+      </label>
+      <input id="password" type="password" [(ngModel)]="password" name="password" required
+             class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 mb-3 leading-tight focus:outline-none focus:shadow-outline" />
+    </div>
+    <div class="flex items-center justify-between">
+      <button class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" type="submit">
+        Iniciar sesión
+      </button>
+    </div>
+  </form>
+</div>

--- a/src/app/modules/login/components/login/login.component.scss
+++ b/src/app/modules/login/components/login/login.component.scss
@@ -1,0 +1,1 @@
+/* Estilos básicos para el formulario de login */

--- a/src/app/modules/login/components/login/login.component.spec.ts
+++ b/src/app/modules/login/components/login/login.component.spec.ts
@@ -1,0 +1,27 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+
+import { LoginComponent } from './login.component';
+
+describe('LoginComponent', () => {
+  let component: LoginComponent;
+  let fixture: ComponentFixture<LoginComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ LoginComponent ],
+      imports: [FormsModule]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LoginComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/login/components/login/login.component.ts
+++ b/src/app/modules/login/components/login/login.component.ts
@@ -1,0 +1,20 @@
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+
+@Component({
+  selector: 'app-login',
+  templateUrl: './login.component.html',
+  styleUrls: ['./login.component.scss']
+})
+export class LoginComponent {
+  email = '';
+  password = '';
+
+  constructor(private router: Router) {}
+
+  login() {
+    // En un escenario real se implementaría la autenticación
+    console.log('Logging in with', this.email);
+    this.router.navigate(['/products']);
+  }
+}

--- a/src/app/modules/login/login-routing.module.ts
+++ b/src/app/modules/login/login-routing.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { LoginComponent } from './components/login/login.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: LoginComponent
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class LoginRoutingModule { }

--- a/src/app/modules/login/login.module.ts
+++ b/src/app/modules/login/login.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+import { LoginRoutingModule } from './login-routing.module';
+import { LoginComponent } from './components/login/login.component';
+import { SharedModule } from '../../shared/shared.module';
+
+@NgModule({
+  declarations: [
+    LoginComponent
+  ],
+  imports: [
+    CommonModule,
+    FormsModule,
+    LoginRoutingModule,
+    SharedModule
+  ]
+})
+export class LoginModule { }

--- a/src/app/shared/components/header/header.component.html
+++ b/src/app/shared/components/header/header.component.html
@@ -35,6 +35,11 @@
               {{ cartItems.length }}
             </span>
           </button>
+
+          <!-- Botón de inicio de sesión -->
+          <button routerLink="/login" class="ml-4 text-white bg-blue-600 hover:bg-blue-700 px-3 py-1 rounded">
+            Iniciar sesión / Registrarse
+          </button>
   
           <!-- Profile dropdown -->
           <div class="relative ml-3 group">


### PR DESCRIPTION
## Summary
- add new login module with basic form
- wire login lazy route in app routing
- add login button in header navigation

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68483058f154832a8974cb162b2eeb6f